### PR TITLE
Feature new devices

### DIFF
--- a/0404d3cf-c44d-4f9b-83a5-74f54ca10317.json
+++ b/0404d3cf-c44d-4f9b-83a5-74f54ca10317.json
@@ -1,0 +1,161 @@
+{
+  "id": "0404d3cf-c44d-4f9b-83a5-74f54ca10317",
+  "label": {
+    "entry": [
+      {
+        "key": "en",
+        "value": [
+          "Door/Window Sensor 2"
+        ]
+      }
+    ]
+  },
+  "description": {},
+  "binding_config": {
+    "meta_config": {
+      "entry": [
+        {
+          "key": "OPENHAB_BINDING_TYPE",
+          "value": "zwave"
+        }
+      ]
+    }
+  },
+  "company": "Fibaro",
+  "shape": {
+    "bounding_box": {}
+  },
+  "unit_template_config": [
+    {
+      "id": "0404d3cf-c44d-4f9b-83a5-74f54ca10317_REED_CONTACT_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "REED_CONTACT_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "REED_CONTACT",
+      "service_template_config": [
+        {
+          "service_type": "CONTACT_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "sensor_door"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    },
+    {
+      "id": "0404d3cf-c44d-4f9b-83a5-74f54ca10317_BATTERY_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "BATTERY_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "BATTERY",
+      "service_template_config": [
+        {
+          "service_type": "BATTERY_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "battery-level"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    },
+    {
+      "id": "0404d3cf-c44d-4f9b-83a5-74f54ca10317_TEMPERATURE_SENSOR_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "TEMPERATURE_SENSOR_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "TEMPERATURE_SENSOR",
+      "service_template_config": [
+        {
+          "service_type": "TEMPERATURE_ALARM_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "alarm_heat"
+              }
+            ]
+          }
+        },
+        {
+          "service_type": "TEMPERATURE_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "sensor_temperature"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    },
+    {
+      "id": "0404d3cf-c44d-4f9b-83a5-74f54ca10317_TAMPER_DETECTOR_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "TAMPER_DETECTOR_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "TAMPER_DETECTOR",
+      "service_template_config": [
+        {
+          "service_type": "TAMPER_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "alarm_tamper"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    }
+  ],
+  "meta_config": {
+    "entry": [
+      {
+        "key": "OPENHAB_THING_CLASS",
+        "value": "zwave_devicetype:1794"
+      }
+    ]
+  }
+}

--- a/36edd2d3-1000-487d-99f2-ab9152285399.json
+++ b/36edd2d3-1000-487d-99f2-ab9152285399.json
@@ -1,0 +1,84 @@
+{
+  "id": "36edd2d3-1000-487d-99f2-ab9152285399",
+  "label": {
+    "entry": [
+      {
+        "key": "en",
+        "value": [
+          "Philips Hue Filament Bulb Gen 1"
+        ]
+      }
+    ]
+  },
+  "product_number": "LWO001",
+  "description": {},
+  "binding_config": {
+    "binding_id": "OPENHAB",
+    "meta_config": {
+      "entry": [
+        {
+          "key": "OPENHAB_BINDING_TYPE",
+          "value": "hue"
+        }
+      ]
+    }
+  },
+  "company": "Philips",
+  "shape": {
+    "bounding_box": {
+      "left_front_bottom": {},
+      "width": 0.0,
+      "depth": 0.0,
+      "height": 0.0
+    }
+  },
+  "unit_template_config": [
+    {
+      "id": "36edd2d3-1000-487d-99f2-ab9152285399_DIMMABLE_LIGHT_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "DIMMABLE_LIGHT_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "DIMMABLE_LIGHT",
+      "service_template_config": [
+        {
+          "service_type": "POWER_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "brightness"
+              }
+            ]
+          }
+        },
+        {
+          "service_type": "BRIGHTNESS_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "brightness"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    }
+  ],
+  "meta_config": {
+    "entry": [
+      {
+        "key": "OPENHAB_THING_CLASS",
+        "value": "modelId:LWO001"
+      }
+    ]
+  }
+}

--- a/3eef6549-60d5-4c88-ae80-5b9a190ce951.json
+++ b/3eef6549-60d5-4c88-ae80-5b9a190ce951.json
@@ -1,0 +1,161 @@
+{
+  "id": "3eef6549-60d5-4c88-ae80-5b9a190ce951",
+  "label": {
+    "entry": [
+      {
+        "key": "en",
+        "value": [
+          "Philips Hue Motion Sensor Gen 1"
+        ]
+      }
+    ]
+  },
+  "product_number": "SML001",
+  "description": {},
+  "binding_config": {
+    "binding_id": "OPENHAB",
+    "meta_config": {
+      "entry": [
+        {
+          "key": "OPENHAB_BINDING_TYPE",
+          "value": "hue"
+        }
+      ]
+    }
+  },
+  "company": "Philips",
+  "shape": {
+    "bounding_box": {
+      "left_front_bottom": {},
+      "width": 0.0,
+      "depth": 0.0,
+      "height": 0.0
+    }
+  },
+  "unit_template_config": [
+    {
+      "id": "3eef6549-60d5-4c88-ae80-5b9a190ce951_MOTION_DETECTOR_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "MOTION_DETECTOR_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "MOTION_DETECTOR",
+      "service_template_config": [
+        {
+          "service_type": "MOTION_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "presence"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    },
+    {
+      "id": "3eef6549-60d5-4c88-ae80-5b9a190ce951_BATTERY_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "BATTERY_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "BATTERY",
+      "service_template_config": [
+        {
+          "service_type": "BATTERY_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "battery_level"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    },
+    {
+      "id": "3eef6549-60d5-4c88-ae80-5b9a190ce951_TEMPERATURE_SENSOR_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "TEMPERATURE_SENSOR_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "TEMPERATURE_SENSOR",
+      "service_template_config": [
+        {
+          "service_type": "TEMPERATURE_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "temperature"
+              }
+            ]
+          }
+        },
+        {
+          "service_type": "TEMPERATURE_ALARM_STATE_SERVICE",
+          "meta_config": {}
+        }
+      ],
+      "meta_config": {}
+    },
+    {
+      "id": "3eef6549-60d5-4c88-ae80-5b9a190ce951_LIGHT_SENSOR_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "LIGHT_SENSOR_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "LIGHT_SENSOR",
+      "service_template_config": [
+        {
+          "service_type": "ILLUMINANCE_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "illuminance"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    }
+  ],
+  "meta_config": {
+    "entry": [
+      {
+        "key": "OPENHAB_THING_CLASS",
+        "value": "modelId:SML001"
+      }
+    ]
+  }
+}

--- a/b6230efc-e090-4b17-bfb6-f995f7dc7c3a.json
+++ b/b6230efc-e090-4b17-bfb6-f995f7dc7c3a.json
@@ -1,0 +1,84 @@
+{
+  "id": "b6230efc-e090-4b17-bfb6-f995f7dc7c3a",
+  "label": {
+    "entry": [
+      {
+        "key": "en",
+        "value": [
+          "Philips Hue White E27 Gen 1"
+        ]
+      }
+    ]
+  },
+  "product_number": "LWA001",
+  "description": {},
+  "binding_config": {
+    "binding_id": "OPENHAB",
+    "meta_config": {
+      "entry": [
+        {
+          "key": "OPENHAB_BINDING_TYPE",
+          "value": "hue"
+        }
+      ]
+    }
+  },
+  "company": "Philips",
+  "shape": {
+    "bounding_box": {
+      "left_front_bottom": {},
+      "width": 0.0,
+      "depth": 0.0,
+      "height": 0.0
+    }
+  },
+  "unit_template_config": [
+    {
+      "id": "b6230efc-e090-4b17-bfb6-f995f7dc7c3a_DIMMABLE_LIGHT_0",
+      "label": {
+        "entry": [
+          {
+            "key": "en",
+            "value": [
+              "DIMMABLE_LIGHT_0"
+            ]
+          }
+        ]
+      },
+      "unit_type": "DIMMABLE_LIGHT",
+      "service_template_config": [
+        {
+          "service_type": "POWER_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "brightness"
+              }
+            ]
+          }
+        },
+        {
+          "service_type": "BRIGHTNESS_STATE_SERVICE",
+          "meta_config": {
+            "entry": [
+              {
+                "key": "OPENHAB_THING_CHANNEL_TYPE_UID",
+                "value": "brightness"
+              }
+            ]
+          }
+        }
+      ],
+      "meta_config": {}
+    }
+  ],
+  "meta_config": {
+    "entry": [
+      {
+        "key": "OPENHAB_THING_CLASS",
+        "value": "modelId:LWA001"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add the following device classes with the following units:

- Fibaro Door Window Sensor 2
  - Reed Contact
  - Temperature Sensor
  - Tamper Detector
  - Battery
- Philips Hue Motion Sensor
  - Motion Detector
  - Temperature Sensor
  - Light Sensor
  - Battery
- Philips Filament Bulb Gen 1
  - Dimmable Light
- Philips Hue White E27 Gen 1
  - Dimmable LIght

Note that there currently exists a bug with the automatic registration of the Philips Hue Motion Sensor over OpenHAB: openbase/bco.device#76